### PR TITLE
Remove non-ascii character from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ with integrated OpenTracing tracers.
 Further Information
 ===================
 
-If you’re interested in learning more about the OpenTracing standard, please visit `opentracing.io`_ or `join the mailing list`_. If you would like to implement OpenTracing in your project and need help, feel free to send us a note at `community@opentracing.io`_.
+If you're interested in learning more about the OpenTracing standard, please visit `opentracing.io`_ or `join the mailing list`_. If you would like to implement OpenTracing in your project and need help, feel free to send us a note at `community@opentracing.io`_.
 
 .. _opentracing.io: http://opentracing.io/
 .. _join the mailing list: http://opentracing.us13.list-manage.com/subscribe?u=180afe03860541dae59e84153&id=19117aa6cd


### PR DESCRIPTION
The python packaging doesn't declare itself to prefer utf-8, but the README contains it, so the `long_description=open('README.rst').read()` is failing with:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3800: ordinal not in range(128)

There's only this single character, though, so just replace it with ASCII and solve the issue the easy way.