### PR TITLE
Allow the underlying tracer initialization to be deferred

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,33 @@ instance of an OpenTracing tracer. You can either trace all requests to your sit
 
 **Note:** `optional_args` in both cases are any number of attributes (as strings) of `flask.Request` that you wish to set as tags on the created span
 
+Initialize
+----------
+
+`FlaskTracer` wraps the tracer instance that's supported by opentracing. To create a `FlaskTracer` object, you can either pass in a tracer object directly or a callable that returns the tracer object. For example:
+
+.. code-block:: python
+
+    import opentracing
+    from flask_opentracing import FlaskTracer
+
+    opentracing_tracer = ## some OpenTracing tracer implementation
+    tracer = FlaskTracer(opentracing_tracer, ...)
+
+or
+
+.. code-block:: python
+
+    import opentracing
+    from flask_opentracing import FlaskTracer
+
+    def initialize_tracer():
+        ...
+        return opentracing_tracer
+
+    tracer = FlaskTracer(initialize_tracer, ...)
+
+
 Trace All Requests
 ------------------
 


### PR DESCRIPTION
For some tracer implementation (like [Jaeger](https://github.com/jaegertracing/jaeger-client-python/issues/60)), the initialization of the tracer should be deferred until the wsgi server forks. We cannot directly create a jaeger tracer instance and pass it to `FlaskTracer` constructor upon startup.

This PR addresses this issue. The underlying tracer initialization can be deferred if we pass a callable as argument to the constructor.