### PR TITLE
Add default to _after_request_fn

### DIFF
--- a/flask_opentracing/tracer.py
+++ b/flask_opentracing/tracer.py
@@ -92,6 +92,7 @@ class FlaskTracer(opentracing.Tracer):
 
     def _after_request_fn(self):
         request = stack.top.request
-        span = self._current_spans.pop(request)
+        # the pop call can fail if the request is interrupted by a `before_request` method so we need a default
+        span = self._current_spans.pop(request, None)
         if span is not None:
             span.finish()


### PR DESCRIPTION
If the flask app has a `before_request` method that shortcuts request execution, the request will not be present in the `_current_spans` dict but the tracer will still try to finish the span. Adding this default prevents an exception on those calls.