### PR TITLE
Adopt FlaskScopeManager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,35 @@ If you want to make an RPC and continue an existing trace, you can inject the cu
             new_request.add_header(k,v)
         ... # make request
 
+FlaskScopeManager
+-----------------
+
+By default, Flask-OpenTracing will attempt to track spans initiated by view functions in the request context.  However, to fully ensure parent-child span relationships throughout your Flask application in any deployment configuration, a FlaskScopeManager is provided.
+
+.. code-block:: python
+
+    from my_opentracing_tracer import OpenTracingTracer
+    from flask_opentracing import FlaskTracer, FlaskScopeManager
+
+    app = Flask(__name__)
+
+    opentracing_tracer = OpenTracingTracer(FlaskScopeManager())
+    # trace all requests
+    tracing = FlaskTracing(opentracing_tracer, True, app, [optional_args])
+
+    @app.route('/some_url')
+    def some_view_func():
+        helper_function()
+        ...
+        return some_view
+
+
+    def helper_function():
+        # spans created in your application will be children of parent spans
+        # automatically created for your traced view function.
+        with opentracing_tracer.start_active_span('MyChildSpan') as scope
+            scope.span.set_tag('HelpfulKey', 'HelpfulValue')
+
 Examples
 ========
 

--- a/flask_opentracing/__init__.py
+++ b/flask_opentracing/__init__.py
@@ -1,2 +1,3 @@
 from .tracing import FlaskTracing  # noqa
 from .tracing import FlaskTracing as FlaskTracer  # noqa, deprecated
+from .scope_manager import FlaskScopeManager  # noqa

--- a/flask_opentracing/scope_manager.py
+++ b/flask_opentracing/scope_manager.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+
+from flask import _request_ctx_stack as stack
+
+from opentracing.scope_managers import ThreadLocalScopeManager
+from opentracing import Scope
+
+
+class FlaskScopeManager(ThreadLocalScopeManager):
+    """
+    opentracing.ScopeManager implementation for Flask that stores
+    the opentracing.Scope in a Flask RequestContext, made accessible
+    via flask._request_ctx_stack.
+    """
+    @property
+    def _context(self):
+        # Default to ThreadLocalScopeManager._tls_scope for usage outside
+        # app/request context (unit tests)
+        if stack.top is None:
+            return self._tls_scope
+        return stack.top
+
+    @property
+    def _active_attr(self):
+        """
+        Make an instance-specific attribute with which to pin active
+        opentracing.Scope.  Necessary in cases of multiple tracers,
+        to prevent scope creep.
+        """
+        return '__ot_{0}'.format(id(self))
+
+    def activate(self, span, finish_on_close):
+        """
+        Make a opentracing.Span instance active. Returns an opentracing.Scope
+        instance to control the end of the active period for the
+        opentracing.Span. It is a programming error to neglect to call
+        Scope.close() on the returned instance.
+
+        @param span the opentracing.Span that should become active.
+        @param finish_on_close whether span should automatically be finished
+         when Scope.close() is called.
+
+        """
+        scope = _FlaskScope(self, span, finish_on_close)
+        setattr(self._context, self._active_attr, scope)
+        return scope
+
+    @property
+    def active(self):
+        """
+        Returns the currently active opentracing.Scope which can be used to
+        access the currently active Scope.span or None if not available.
+        """
+        return getattr(self._context, self._active_attr, None)
+
+
+class _FlaskScope(Scope):
+
+    def __init__(self, manager, span, finish_on_close):
+        super(_FlaskScope, self).__init__(manager, span)
+        self._finish_on_close = finish_on_close
+        self._to_restore = manager.active
+
+    def close(self):
+        if self.manager.active is not self:
+            return
+
+        if self._finish_on_close:
+            self.span.finish()
+
+        setattr(self.manager._context, self.manager._active_attr,
+                self._to_restore)


### PR DESCRIPTION
These changes introduce an optional scope manager using Flask's stack, as originally proposed in  https://github.com/opentracing/opentracing-python/pull/105.

This is helpful for ensuring that the active span obtained anywhere in a view function's call chain is guaranteed to be associated with request as provided by werkzeug's context locals.