### PR TITLE
Add explicit empty string check on tagged attributes

### DIFF
--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -133,9 +133,9 @@ class FlaskTracing(opentracing.Tracer):
 
         for attr in attributes:
             if hasattr(request, attr):
-                payload = str(getattr(request, attr))
-                if payload:
-                    span.set_tag(attr, payload)
+                payload = getattr(request, attr)
+                if payload not in ('', b''):  # python3
+                    span.set_tag(attr, str(payload))
 
         self._call_start_span_cb(span, request)
 

--- a/tests/test_flask_tracing.py
+++ b/tests/test_flask_tracing.py
@@ -36,7 +36,7 @@ def decorated_fn():
 
 
 @app.route('/another_test_simple')
-@tracing.trace()
+@tracing.trace('query_string', 'is_xhr')
 def decorated_fn_simple():
     return 'Success again'
 
@@ -101,6 +101,7 @@ class TestTracing(unittest.TestCase):
             tags.HTTP_METHOD: 'GET',
             tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,
             tags.HTTP_URL: 'http://localhost/another_test_simple',
+            'is_xhr': 'False',
         }
 
     def test_requests_distinct(self):


### PR DESCRIPTION
The current cast to string before boolean check for whether to include a request attribute's value in a tag leads to `"b''"` values for empty query strings in python 3.  This is inconsistent w/ what I'm assuming is the desired python 2 behavior of not including the tag.

This change expands the falsey string check to an explicit comparison of empty string and byte string.