### PR TITLE
Extended traced_attributes scope to after_request (response) too

### DIFF
--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -135,7 +135,7 @@ class FlaskTracing(opentracing.Tracer):
             if hasattr(request, attr):
                 payload = str(getattr(request, attr))
                 if payload:
-                    span.set_tag(attr, payload)
+                    span.set_tag('request_' + attr, payload)
 
         self._call_start_span_cb(span, request)
 
@@ -163,7 +163,7 @@ class FlaskTracing(opentracing.Tracer):
             if hasattr(response, attr):
                 payload = str(getattr(response, attr))
                 if payload:
-                    span.set_tag(attr, payload)
+                    span.set_tag('response_' + attr, payload)
 
         scope.close()
 

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -133,9 +133,9 @@ class FlaskTracing(opentracing.Tracer):
 
         for attr in attributes:
             if hasattr(request, attr):
-                payload = str(getattr(request, attr))
+                payload = getattr(request, attr)
                 if payload not in ('', b''):  # python3
-                    span.set_tag('request_' + attr, payload)
+                    span.set_tag('request_' + attr, str(payload))
 
         self._call_start_span_cb(span, request)
 
@@ -151,6 +151,11 @@ class FlaskTracing(opentracing.Tracer):
         span = scope.span
         if response is not None:
             span.set_tag(tags.HTTP_STATUS_CODE, response.status_code)
+            for attr in attributes:
+                if hasattr(response, attr):
+                    payload = getattr(response, attr)
+                    if payload not in ('', b''):  # python3
+                        span.set_tag('response_' + attr, str(payload))
         if error is not None:
             span.set_tag(tags.ERROR, True)
             span.log_kv({
@@ -158,11 +163,6 @@ class FlaskTracing(opentracing.Tracer):
                 'error.object': error,
             })
 
-        for attr in attributes:
-            if hasattr(response, attr):
-                payload = str(getattr(response, attr))
-                if payload not in ('', b''):  # python3
-                    span.set_tag('response_' + attr, payload)
 
         scope.close()
 

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -163,7 +163,6 @@ class FlaskTracing(opentracing.Tracer):
                 'error.object': error,
             })
 
-
         scope.close()
 
     def _call_start_span_cb(self, span, request):

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -158,7 +158,6 @@ class FlaskTracing(opentracing.Tracer):
                 'error.object': error,
             })
 
-
         for attr in attributes:
             if hasattr(response, attr):
                 payload = str(getattr(response, attr))

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -80,12 +80,12 @@ class FlaskTracing(opentracing.Tracer):
                 self._before_request_fn(list(attributes))
                 try:
                     r = f(*args, **kwargs)
-                    self._after_request_fn()
+                    self._after_request_fn(list(attributes))
                 except Exception as e:
                     self._after_request_fn(error=e)
                     raise
 
-                self._after_request_fn()
+                self._after_request_fn(list(attributes))
                 return r
 
             wrapper.__name__ = f.__name__

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -46,7 +46,7 @@ class FlaskTracing(opentracing.Tracer):
             @app.teardown_request
             def end_trace_with_error(error):
                 if error is not None:
-                    self._after_request_fn(error=error)
+                    self._after_request_fn(traced_attributes, error=error)
 
     @property
     def _tracer(self):
@@ -82,7 +82,7 @@ class FlaskTracing(opentracing.Tracer):
                     r = f(*args, **kwargs)
                     self._after_request_fn(list(attributes))
                 except Exception as e:
-                    self._after_request_fn(error=e)
+                    self._after_request_fn(list(attributes), error=e)
                     raise
 
                 self._after_request_fn(list(attributes))

--- a/tests/test_flask_tracing.py
+++ b/tests/test_flask_tracing.py
@@ -101,7 +101,7 @@ class TestTracing(unittest.TestCase):
             tags.HTTP_METHOD: 'GET',
             tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,
             tags.HTTP_URL: 'http://localhost/another_test_simple',
-            'is_xhr': 'False',
+            'request_is_xhr': 'False',
         }
 
     def test_requests_distinct(self):


### PR DESCRIPTION
Traced_attributes is given and scanned in _after_request_fn too.
The motivation is that this way the attributes of the response object could be presented in the trace also.
Our goal is to have more control over the traced attributes because our task requires also the input and the output data in one point.
