### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,30 @@
+dist: xenial
 language: python
 python:
-  - "2.7"
-  - "3.6"
-# command to install dependencies
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8-dev'
+  - 'nightly'
+  - 'pypy'
+  - 'pypy3.5'
+
+stages:
+  - lint
+  - test
+
+matrix:
+  include:
+    - stage: lint
+      name: flake8
+      python: '3.7'
+  allow_failures:
+    - python: '3.8-dev'
+    - python: 'nightly'
+
 install:
-  - make bootstrap
-# command to run tests
+  - pip install tox-travis
+
 script:
-  -  make test lint
+  - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,14 @@ test=pytest
 
 [metadata]
 description-file = README.rst
+
+[tool:pytest]
+addopts =
+    --tb short
+    -rxs
+    --cov-report term-missing:skip-covered
+    --cov flask_opentracing
+    tests
+
+[coverage:run]
+branch = True

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
     ],
     extras_require={
         'tests': [
-            'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
+            'flake8',
             'flake8-quotes',
             'mock',
-            'pytest>=3.6,<4',
+            'pytest',
             'pytest-cov',
         ],
     },
@@ -40,6 +40,14 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/tests/test_flask_tracing.py
+++ b/tests/test_flask_tracing.py
@@ -156,7 +156,7 @@ class TestTracing(unittest.TestCase):
         assert len(tracing_deferred._current_scopes) == 0
 
         # Registered handler.
-        spans = tracing_all.tracer.finished_spans()
+        spans = tracing.tracer.finished_spans()
         assert len(spans) == 1
         self._verify_error(spans[0])
 
@@ -166,7 +166,7 @@ class TestTracing(unittest.TestCase):
         self._verify_error(spans[0])
 
     def _verify_error(self, span):
-        assert span.tags.get(tags.ERROR, None) is True
+        assert span.tags.get(tags.ERROR) is True
 
         assert len(span.logs) == 1
         assert span.logs[0].key_values.get('event', None) is tags.ERROR

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py27,py3{5,6,7,8},pypy{,3},flake8
+skip_missing_interpreters = true
+
+[travis]
+python =
+    3.7: py37,flake8
+
+[travis:env]
+TRAVIS_BUILD_STAGE_NAME =
+    Lint: flake8
+    Test: py27,py3{5,6,7,8},pypy{,3}
+
+[testenv:flake8]
+basepython = python3.7
+deps =
+    flake8
+    flake8-quotes
+commands = flake8 flask_opentracing tests
+
+[testenv]
+extras = tests
+commands =
+    pytest


### PR DESCRIPTION
Hello @carlosalberto and @yurishkuro,

I believe that it would be nice to have tests for all modern and upcoming versions of Python.

These changes:
 - fix `TestTracing.test_error` for the latest Flask
 - add `tox.ini`
 - make Travis CI use `tox`
 - add test jobs for various Python versions
 - add missing classifiers to `setup.py`
 - enable the [branch coverage](https://coverage.readthedocs.io/en/latest/branch.html) feature

Best regards!