### PR TITLE
Add tag with status code to http responses

### DIFF
--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -80,7 +80,7 @@ class FlaskTracing(opentracing.Tracer):
                 self._before_request_fn(list(attributes))
                 try:
                     r = f(*args, **kwargs)
-                    self._after_request_fn()
+                    self._after_request_fn(response=r)
                 except Exception as e:
                     self._after_request_fn(error=e)
                     raise


### PR DESCRIPTION
I think this change fixes #45 , sending the http response to the after request function so the tag will be added [here](https://github.com/Fortiz2305/python-flask/blob/master/flask_opentracing/tracing.py#L152)