### PR TITLE
Updates for compatibility with Flask 3.0 and recent Python versions

### DIFF
--- a/example/client.py
+++ b/example/client.py
@@ -1,3 +1,10 @@
+import sys
+if sys.version_info[:2] >= (3, 10):
+    # compat for Python written pre-3.10
+    import collections
+    import collections.abc
+    collections.MutableMapping = collections.abc.MutableMapping
+
 import requests
 import time
 from opentracing_instrumentation.client_hooks import install_all_patches

--- a/example/server.py
+++ b/example/server.py
@@ -1,3 +1,10 @@
+import sys
+if sys.version_info[:2] >= (3, 10):
+    # compat for Python written pre-3.10
+    import collections
+    import collections.abc
+    collections.MutableMapping = collections.abc.MutableMapping
+
 import logging
 from jaeger_client import Config
 from flask_opentracing import FlaskTracing

--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -1,6 +1,6 @@
 import opentracing
 from opentracing.ext import tags
-from flask import _request_ctx_stack as stack
+from flask import request as flask_current_request
 
 
 class FlaskTracing(opentracing.Tracer):
@@ -101,14 +101,14 @@ class FlaskTracing(opentracing.Tracer):
 
         @param request the request to get the span from
         """
-        if request is None and stack.top:
-            request = stack.top.request
+        if request is None:
+            request = flask_current_request
 
         scope = self._current_scopes.get(request, None)
         return None if scope is None else scope.span
 
     def _before_request_fn(self, attributes):
-        request = stack.top.request
+        request = flask_current_request
         operation_name = request.endpoint
         headers = {}
         for k, v in request.headers:
@@ -140,7 +140,7 @@ class FlaskTracing(opentracing.Tracer):
         self._call_start_span_cb(span, request)
 
     def _after_request_fn(self, response=None, error=None):
-        request = stack.top.request
+        request = flask_current_request
 
         # the pop call can fail if the request is interrupted by a
         # `before_request` method so we need a default

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # add dependencies in setup.py
   
 -r requirements.txt
+tox
 
 -e .[tests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [tool:pytest]
 addopts =

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
             'mock',
             'pytest',
             'pytest-cov',
+            'tox',
         ],
     },
     classifiers=[

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -5,4 +5,5 @@ Run the tests with the following command:
 
 .. code-block:: 
 
-    $ python setup.py test
+    $ pip install -r requirements-test.txt
+    $ tox

--- a/tests/test_flask_tracing_span_callbacks.py
+++ b/tests/test_flask_tracing_span_callbacks.py
@@ -1,0 +1,59 @@
+import unittest
+from abc import abstractmethod
+
+from flask import Flask
+from opentracing.ext import tags
+from opentracing.mocktracer import MockTracer
+from flask_opentracing import FlaskTracing
+
+
+class _StartSpanCallbackTestCase(unittest.TestCase):
+    @staticmethod
+    @abstractmethod
+    def start_span_cb(span, request):
+        pass
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.tracing = FlaskTracing(
+            MockTracer(), True, self.app, start_span_cb=self.start_span_cb
+        )
+        self.test_app = self.app.test_client()
+
+        @self.app.route('/test')
+        def check_test_works():
+            return 'Success'
+
+
+class TestFlaskTracingStartSpanCallbackSetTags(_StartSpanCallbackTestCase):
+    @staticmethod
+    def start_span_cb(span, request):
+        print('setting tags')
+        span.set_tag('component', 'not-flask')
+        span.set_tag('mytag', 'myvalue')
+
+    def test_simple(self):
+        rv = self.test_app.get('/test')
+        assert '200' in str(rv.status_code)
+
+        spans = self.tracing.tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].tags.get(tags.COMPONENT, None) == 'not-flask'
+        assert spans[0].tags.get('mytag', None) == 'myvalue'
+
+
+class TestFlaskTracingStartSpanCallbackRaisesError(
+    _StartSpanCallbackTestCase
+):
+    @staticmethod
+    def start_span_cb(span, request):
+        print('raising exception')
+        raise RuntimeError('Should not happen')
+
+    def test_error(self):
+        rv = self.test_app.get('/test')
+        assert '200' in str(rv.status_code)
+
+        spans = self.tracing.tracer.finished_spans()
+        assert len(spans) == 1
+        assert spans[0].tags.get(tags.ERROR, None) is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3{5,6,7,8},pypy{,3},flake8
+envlist = py27,py3{5,6,7,8,9,10,11,12},pypy{,3},flake8
 skip_missing_interpreters = true
 
 [travis]
@@ -19,6 +19,8 @@ deps =
 commands = flake8 flask_opentracing tests
 
 [testenv]
+deps =
+    flaky
 extras = tests
 commands =
     pytest


### PR DESCRIPTION
- remove usage of deprecated Flask variable `_request_ctx_stack`, use `request` (backward compatible with Flask 2.x versions)
- refactor span callback tests to address change in Flask where before/after request callbacks can't be added to an app once it has started serving requests
- add `flaky` decorator to `test_request_distinct` and `test_over_wire` unit tests
- add Python 3.10 compatibility hack to example server and client scripts
- change testing to use `tox` instead of deprecated `python setup.py test`
- add recent Python versions to` tox.ini` `envlist`

Fixes #59 