### PR TITLE
Add HTTP_STATUS_CODE to responses

### DIFF
--- a/flask_opentracing/tracing.py
+++ b/flask_opentracing/tracing.py
@@ -78,14 +78,15 @@ class FlaskTracing(opentracing.Tracer):
                     return f(*args, **kwargs)
 
                 self._before_request_fn(list(attributes))
+
                 try:
                     r = f(*args, **kwargs)
-                    self._after_request_fn()
                 except Exception as e:
                     self._after_request_fn(error=e)
                     raise
 
-                self._after_request_fn()
+                self._after_request_fn(response=r)
+
                 return r
 
             wrapper.__name__ = f.__name__

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     flaky
 extras = tests
 commands =
-    pytest
+    pytest {posargs}


### PR DESCRIPTION
Changes largely cloned from PR #46.
Also some minimal code cleanup - remove redundant call to _after_request_fn; update tox.ini to accept pytest command line args